### PR TITLE
Don't set default sentinel config path to /root/

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -1,6 +1,6 @@
 # specify path to quantisnet.conf or leave blank
 # default is the same as QuantisNetCore
-quantisnet_conf=/root/.quantisnetcore/quantisnet.conf
+#quantisnet_conf=/root/.quantisnetcore/quantisnet.conf
 
 # valid options are mainnet, testnet, or testnet60x (default=mainnet)
 network=mainnet


### PR DESCRIPTION
As explained in the line above the changed line, the default already sets it to the same config file as the daemon.  
Setting it to /root/ manually will only work if Sentinel is being run as root (which no-one should be doing on a good setup).